### PR TITLE
Fix build issues

### DIFF
--- a/src/ImageClassification/ImageClassification.Score.csproj
+++ b/src/ImageClassification/ImageClassification.Score.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="0.6.0-preview-26919-7" />
-    <PackageReference Include="Microsoft.ML.CpuMath" Version="0.6.0-preview-26919-7" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="0.6.0-preview-26919-7" />
-    <PackageReference Include="Microsoft.ML.TensorFlow" Version="0.6.0-preview-26919-7" />
+    <PackageReference Include="Microsoft.ML" Version="0.6.0" />
+    <PackageReference Include="Microsoft.ML.CpuMath" Version="0.6.0" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="0.6.0" />
+    <PackageReference Include="Microsoft.ML.TensorFlow" Version="0.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ImageClassification/ImageData/ImageNetData.cs
+++ b/src/ImageClassification/ImageData/ImageNetData.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.ML.Data.StaticPipe.Runtime;
-using Microsoft.ML.Runtime.Api;
+﻿using Microsoft.ML.Runtime.Api;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
Hi!

I was looking for an example in c# to make predictions with inception v3 model. Unfortunately, I had issues building the project.

It seems like the preview version is not listed anymore on NuGet. So, I removed the suffix "-preview-26919-7". I also removed the using "Microsoft.ML.Data.StaticPipe.Runtime". Nothing seem to use it anyway.

It works perfectly fine now and it gave me reasonable results.

Thank you!